### PR TITLE
Members in comet http errors must be public

### DIFF
--- a/Sources/Comet/CometClient/CometClientHttpError.swift
+++ b/Sources/Comet/CometClient/CometClientHttpError.swift
@@ -5,6 +5,6 @@
 import Foundation
 
 public struct CometClientHttpError {
-    let code: Int
-    let data: Data
+    public let code: Int
+    public let data: Data
 }

--- a/Sources/Comet/TokenProviding/TokenProvidingHttpError.swift
+++ b/Sources/Comet/TokenProviding/TokenProvidingHttpError.swift
@@ -5,6 +5,11 @@
 import Foundation
 
 public struct TokenProvidingHttpError {
-    let code: Int
-    let data: Data
+    public init(code: Int, data: Data) {
+        self.code = code
+        self.data = data
+    }
+
+    public let code: Int
+    public let data: Data
 }


### PR DESCRIPTION
The CometClientHttpError and TokenProvidingHttpError members must be public to be available to an application using Comet.