### PR TITLE
Add public init to CometClientHttpError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
  - Better network error handling
+ - Public members and init in CometClientHttpError and TokenProvidingHttpError

--- a/Sources/Comet/CometClient/CometClientHttpError.swift
+++ b/Sources/Comet/CometClient/CometClientHttpError.swift
@@ -5,6 +5,11 @@
 import Foundation
 
 public struct CometClientHttpError {
+    public init(code: Int, data: Data) {
+        self.code = code
+        self.data = data
+    }
+
     public let code: Int
     public let data: Data
 }


### PR DESCRIPTION
Because we need to create CometClientHttpError from custom RequestResponseHandler, we need public init in CometClientHttpError.