### PR TITLE
Support for unauthorized(401) response handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
  - Better network error handling
  - Public members and init in CometClientHttpError and TokenProvidingHttpError
+ - Added support for custom handling of 401(unauthorized) HTTP errors 

--- a/Sources/Comet/CometClient/CometClientError.swift
+++ b/Sources/Comet/CometClient/CometClientError.swift
@@ -11,7 +11,7 @@ import Foundation
 /// TODO
 public enum CometClientError: Error {
     case internalError
-    case unauthorized
+    case unauthorized(error: CometClientHttpResponseError)
     case loginRequired
     case parserError(reason: String)
     case networkError(from: URLError)

--- a/Sources/Comet/CometClient/CometClientHttpResponseError.swift
+++ b/Sources/Comet/CometClient/CometClientHttpResponseError.swift
@@ -1,0 +1,15 @@
+//
+// Created by Milan Cap on 04.04.2023.
+//
+
+import Foundation
+
+public struct CometClientHttpResponseError {
+    public init(response: URLResponse, data: Data) {
+        self.response = response
+        self.data = data
+    }
+
+    public let response: URLResponse
+    public let data: Data
+}

--- a/Sources/Comet/RequestResponseHandling/CometRequestResponseHandler.swift
+++ b/Sources/Comet/RequestResponseHandling/CometRequestResponseHandler.swift
@@ -33,7 +33,8 @@ public final class CometRequestResponseHandler: RequestResponseHandling {
                     .mapError { CometClientError.parserError(reason: $0.localizedDescription) }
                     .eraseToAnyPublisher()
         case 401:
-            return Fail(error: CometClientError.unauthorized).eraseToAnyPublisher()
+            let error = CometClientError.clientError(error: CometClientHttpError(code: httpResponse.statusCode, data: data))
+            return Fail(error: error).eraseToAnyPublisher()
         case 402..<500:
             let error = CometClientError.clientError(error: CometClientHttpError(code: httpResponse.statusCode, data: data))
             return Fail(error: error).eraseToAnyPublisher()

--- a/Sources/Comet/UnauthorizedResponseHandling/UnauthorizedResponseHandling.swift
+++ b/Sources/Comet/UnauthorizedResponseHandling/UnauthorizedResponseHandling.swift
@@ -1,0 +1,14 @@
+import Combine
+import Foundation
+
+/// Defines a function that processes the 401 response and returns whether to attempt to refresh the token.
+public protocol UnauthorizedResponseHandling {
+    /// Function that handles 401 response.
+    /// - Parameters:
+    ///   - response: URLResponse from backend
+    ///   - data: payload from the 401 response
+    func handleResponse(
+        response: URLResponse,
+        data: Data
+    ) -> AnyPublisher<CometClient.Output, CometClientError>
+}


### PR DESCRIPTION
Added support for processing 401 - unauthorized response. An interface can be added to CometClient to handle this response. If it is not passed (default), the original behaviour is preserved. There is a function within the interface to handle this type of response, in which the body of the response can be decoded and according to the data passed, return a specific Comet error, or return a result which will result in a standard refresh token invocation.