### PR TITLE
Extend custom HTTP 401(unauthorized) error handling to recurring requ…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Better network error handling
  - Public members and init in CometClientHttpError and TokenProvidingHttpError
  - Added support for custom handling of 401(unauthorized) HTTP errors 
+
+### Fixed
+ - extend custom HTTP 401(unauthorized) error handling to recurring requests after token renewal


### PR DESCRIPTION
Extend custom HTTP 401(unauthorized) error handling to recurring requests after token renewal.

If the original request that returned a 401 with the defined point was repeated after the access token was refreshed, the UnauthorizedResponseHandler was not called to determine whether the token refresh should be invoked. Comet then returned an unauthorized error, although the access token was correctly renewed.